### PR TITLE
Fix login flow and logout cookie

### DIFF
--- a/ui/app/(auth)/callback/page.tsx
+++ b/ui/app/(auth)/callback/page.tsx
@@ -27,13 +27,13 @@ export default function AuthCallback() {
 
         if (error) {
           console.error("❌ OAuth error:", error, errorDescription);
-          router.replace("/login");
+          router.replace("/login?error=1");
           return;
         }
 
         if (!accessToken) {
           console.error("❌ No access token found in URL");
-          router.replace("/login");
+          router.replace("/login?error=1");
           return;
         }
 
@@ -51,13 +51,13 @@ export default function AuthCallback() {
 
         if (sessionError) {
           console.error("❌ Failed to set session:", sessionError);
-          router.replace("/login");
+          router.replace("/login?error=1");
           return;
         }
 
         if (!session) {
           console.error("❌ No session after setting tokens");
-          router.replace("/login");
+          router.replace("/login?error=1");
           return;
         }
 
@@ -147,16 +147,16 @@ export default function AuthCallback() {
             } else {
               // For other errors, log and redirect to login
               console.error("❌ Error checking profile:", profileError);
-              router.replace("/login");
+              router.replace("/login?error=1");
             }
           }
         } catch (err) {
           console.error("❌ Unexpected error in profile check:", err);
-          router.replace("/login");
+          router.replace("/login?error=1");
         }
       } catch (err) {
         console.error("❌ Unexpected error in callback:", err);
-        router.replace("/login");
+        router.replace("/login?error=1");
       }
     };
 

--- a/ui/app/(auth)/login/page.tsx
+++ b/ui/app/(auth)/login/page.tsx
@@ -1,16 +1,29 @@
 // pages/login.tsx
 "use client";
-import React from "react";
+import React, { useEffect } from "react";
 import { supabase } from "@/lib/superbase-clinet";
 import { toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
+import { useSearchParams } from "next/navigation";
 import { GoogleIcon } from "@/icons/google-icon";
+import { ToastProvider } from "@/components/toast-provider";
 
 export default function Login() {
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const loginError = searchParams.get("error");
+    if (loginError) {
+      toast.error("Login failed");
+    }
+  }, [searchParams]);
+
   const handleGoogleSignIn = async () => {
     try {
+      const redirectUrl = `${window.location.origin}/callback`;
       const { error } = await supabase.auth.signInWithOAuth({
         provider: "google",
+        options: { redirectTo: redirectUrl },
       });
 
       if (error) throw error;
@@ -76,6 +89,7 @@ export default function Login() {
           </div>
         </div>
       </div>
+      <ToastProvider />
     </div>
   );
 }

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -1,5 +1,6 @@
 // app/layout.tsx
 import "./globals.css";
+import { ToastProvider } from "@/components/toast-provider";
 
 export const metadata = {
   title: "SkillsConnect",
@@ -13,7 +14,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {children}
+        <ToastProvider />
+      </body>
     </html>
   );
 }

--- a/ui/components/ProfileDropdown.tsx
+++ b/ui/components/ProfileDropdown.tsx
@@ -32,6 +32,7 @@ const ProfileDropdown = ({ userName, onLogout }: ProfileDropdownProps) => {
   const handleLogout = async () => {
     try {
       await supabase.auth.signOut();
+      document.cookie = "sb-access-token=; path=/; max-age=0";
       onLogout();
       setIsOpen(false);
       router.push("/");

--- a/ui/components/header.tsx
+++ b/ui/components/header.tsx
@@ -14,6 +14,7 @@ const Header = () => {
 
   const handleLogout = async () => {
     await supabase.auth.signOut();
+    document.cookie = "sb-access-token=; path=/; max-age=0";
   };
 
   return (


### PR DESCRIPTION
## Summary
- ensure login redirect and login failure messages
- mount ToastProvider globally for notifications
- clear auth cookie on logout

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a7c43e560832782bf3bd7f7cd7468