### PR TITLE
Add responsive meta and sidebar fix

### DIFF
--- a/ui/app/admin/layout.tsx
+++ b/ui/app/admin/layout.tsx
@@ -16,7 +16,7 @@ export default function AdminLayout({
       {/* Sidebar + main layout below */}
       <div className="flex flex-1 overflow-hidden">
         {/* Sidebar with fixed width and full height */}
-        <div className="w-64 shrink-0 overflow-y-auto bg-white border-r">
+        <div className="hidden lg:block w-64 shrink-0 overflow-y-auto bg-white border-r">
           <AdminSidebar />
         </div>
 

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -14,6 +14,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </head>
       <body>
         {children}
         <ToastProvider />

--- a/ui/components/admin-side-bar.tsx
+++ b/ui/components/admin-side-bar.tsx
@@ -14,7 +14,7 @@ export const AdminSidebar = () => {
   const pathname = usePathname();
 
   return (
-    <aside className="bg-gray-800 text-white w-64 min-h-screen hidden lg:block">
+    <aside className="bg-gray-800 text-white w-full min-h-screen">
       <div className="p-6 border-b border-gray-700">
         <h2 className="text-2xl font-bold text-indigo-400">Admin Panel</h2>
       </div>

--- a/ui/components/header.tsx
+++ b/ui/components/header.tsx
@@ -3,6 +3,8 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useState } from "react";
+import { Menu, X } from "lucide-react";
 import { useAuth } from "@/hooks/useAuth";
 import ProfileDropdown from "./ProfileDropdown";
 import { supabase } from "@/lib/superbase-clinet";
@@ -11,6 +13,7 @@ const Header = () => {
   const { user, loading } = useAuth();
   const pathname = usePathname();
   const isRegistrationPage = pathname === "/register";
+  const [mobileOpen, setMobileOpen] = useState(false);
 
   const handleLogout = async () => {
     await supabase.auth.signOut();
@@ -21,32 +24,26 @@ const Header = () => {
     <header className="bg-white shadow border-b">
       <div className="max-w-7xl mx-auto px-4 py-3 flex justify-between items-center">
         {/* Left Section: Logo + Nav */}
-        <div className="flex items-center gap-8">
+        <div className="flex items-center gap-4 md:gap-8">
           {/* Logo + Brand */}
           <div className="flex items-center gap-2">
             <div className="rounded-full bg-blue-600 h-9 w-9 flex items-center justify-center text-white font-bold text-base">
               SC
             </div>
-            <Link
-              href="/"
-              className="text-xl font-bold text-blue-700 tracking-tight"
-            >
+            <Link href="/" className="text-xl font-bold text-blue-700 tracking-tight">
               SkillsConnect
             </Link>
           </div>
 
           {/* Navigation: Jobs, Companies */}
-          <nav className="flex gap-6 text-sm font-medium text-slate-800">
+          <nav className="hidden md:flex gap-6 text-sm font-medium text-slate-800">
             <Link href="/jobs" className="hover:text-blue-600 leading-tight">
               <div className="flex flex-col items-start">
                 <span className="text-sm">Jobs</span>
                 <span className="text-xs text-slate-400">ఉద్యోగాలు</span>
               </div>
             </Link>
-            <Link
-              href="/companies"
-              className="hover:text-blue-600 leading-tight"
-            >
+            <Link href="/companies" className="hover:text-blue-600 leading-tight">
               <div className="flex flex-col items-start">
                 <span className="text-sm">Companies</span>
                 <span className="text-xs text-slate-400">కంపెనీలు</span>
@@ -55,9 +52,18 @@ const Header = () => {
           </nav>
         </div>
 
+        {/* Mobile menu toggle */}
+        <button
+          className="md:hidden text-slate-600"
+          onClick={() => setMobileOpen(!mobileOpen)}
+          aria-label="Toggle menu"
+        >
+          {mobileOpen ? <X size={24} /> : <Menu size={24} />}
+        </button>
+
         {/* Right-side actions */}
         {!isRegistrationPage && (
-          <div className="flex items-center gap-3">
+          <div className="hidden md:flex items-center gap-3">
             {!user && !loading ? (
               <>
                 <Link
@@ -82,6 +88,61 @@ const Header = () => {
           </div>
         )}
       </div>
+
+      {/* Mobile menu */}
+      {mobileOpen && (
+        <div className="md:hidden px-4 pb-4">
+          <nav className="pt-3 pb-2 border-t flex flex-col gap-2 text-sm font-medium text-slate-800">
+            <Link href="/jobs" className="hover:text-blue-600" onClick={() => setMobileOpen(false)}>
+              Jobs
+            </Link>
+            <Link href="/companies" className="hover:text-blue-600" onClick={() => setMobileOpen(false)}>
+              Companies
+            </Link>
+          </nav>
+          {!isRegistrationPage && (
+            <div className="flex flex-col gap-2">
+              {!user && !loading ? (
+                <>
+                  <Link
+                    href="/login"
+                    className="px-4 py-2 border border-blue-600 text-blue-600 rounded-full text-sm font-medium text-center"
+                    onClick={() => setMobileOpen(false)}
+                  >
+                    Login
+                  </Link>
+                  <Link
+                    href="/register"
+                    className="px-4 py-2 bg-red-500 text-white rounded-full text-sm font-medium text-center"
+                    onClick={() => setMobileOpen(false)}
+                  >
+                    Register
+                  </Link>
+                </>
+              ) : user ? (
+                <>
+                  <Link
+                    href="/profile"
+                    className="px-4 py-2 border border-blue-600 text-blue-600 rounded-full text-sm font-medium text-center"
+                    onClick={() => setMobileOpen(false)}
+                  >
+                    Profile
+                  </Link>
+                  <button
+                    onClick={() => {
+                      handleLogout();
+                      setMobileOpen(false);
+                    }}
+                    className="px-4 py-2 bg-red-500 text-white rounded-full text-sm font-medium"
+                  >
+                    Logout
+                  </button>
+                </>
+              ) : null}
+            </div>
+          )}
+        </div>
+      )}
     </header>
   );
 };

--- a/ui/components/job-message.tsx
+++ b/ui/components/job-message.tsx
@@ -6,7 +6,7 @@ export const JobCallToAction = () => {
     <section className="py-12 bg-gradient-to-br from-blue-600 to-blue-700 text-white mt-12">
       <div className="container mx-auto px-4 text-center">
         <h2 className="text-2xl font-bold mb-4">
-          Not finding what you're looking for?
+          Not finding what you&apos;re looking for?
         </h2>
         <p className="text-lg mb-6 max-w-2xl mx-auto">
           Upload your resume and get notified when relevant jobs match your


### PR DESCRIPTION
## Summary
- add viewport meta tag for proper scaling
- hide admin sidebar on small screens
- adjust sidebar component width
- escape apostrophe in job CTA message
- add mobile menu to header

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a80c2f80c8327bce33b61e04d3e4f